### PR TITLE
enhancement: Introduce enviornment variables for aerospike secrets [KO-419]

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Ensure that you have installed the following tools on your machine.
 
 # Deploy
 
+Before deploying, make sure to set following environment variables:
+
+```
+export TF_VAR_aerospike_admin_password=<password>
+export TF_VAR_aerospike_secret_files_path=<path to directory with features.conf and other cert files if any>
+```
+
 To deploy this blueprint into an AWS EKS cluster, you first need to clone the repository. To do so, run these commands:
 
 ```

--- a/aerospike.tf
+++ b/aerospike.tf
@@ -97,7 +97,23 @@ resource "kubernetes_secret" "auth_secret" {
   }
 
   data = {
-    password = "admin123"
+    password = var.aerospike_admin_password
+  }
+
+  type = "Opaque"
+
+  depends_on = [helm_release.aerospike_operator]
+}
+
+resource "kubernetes_secret" "aerospike_secret" {
+  metadata {
+    name      = "aerospike-secret"
+    namespace = local.aerospike_namespace
+  }
+
+  data = {
+    for file in fileset(var.aerospike_secret_files_path, "*") :
+    basename(file) => file("${var.aerospike_secret_files_path}/${file}")
   }
 
   type = "Opaque"

--- a/variables.tf
+++ b/variables.tf
@@ -33,3 +33,14 @@ variable "vpc_cidr" {
   type        = string
   default     = "10.1.0.0/16"
 }
+
+variable "aerospike_admin_password" {
+  description = "password for aerospike admin user"
+  type        = string
+  sensitive   = true
+}
+
+variable "aerospike_secret_files_path" {
+  description = "path of aerospike secret files like feature.conf and tls certs"
+  type        = string
+}


### PR DESCRIPTION
The Aerospike cluster requires two Kubernetes secrets:

auth-secret: Stores the Aerospike admin user's password.

aerospike-secret: Contains necessary files such as features.conf and TLS certificates.

To streamline secret management and enhance security, the following improvements are proposed:

Introduce environment variables to supply the Aerospike admin password and the path to the files used in aerospike-secret.

This avoids hardcoding sensitive credentials in the repository.

It also enables automatic secret creation through Terraform, eliminating the need for manual intervention by users.